### PR TITLE
Simplify UUID generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,8 +83,15 @@ integTest {
     }
 }
 
+
+def numNodes = findProperty('numNodes') as Integer ?: 1
+def numZones = findProperty('numZones') as Integer ?: 1
+
 testClusters.integTest {
     testDistribution = "ARCHIVE"
+
+    if (numZones > 1) numberOfZones = numZones
+    if (numNodes > 1) numberOfNodes = numNodes
 
     // This installs our plugin into the testClusters
     plugin(project.tasks.bundlePlugin.archiveFile)


### PR DESCRIPTION
 -Replace complex UUID generation with simple index name as UUID
- Update ETCDStateDeserializer to use index name directly as UUID  
- Update ETCDIndexMetadataPublisher to filter out constants
- Update READ.ME and build.gradle configuration