### PR TITLE
Fix output file missing version issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -356,3 +356,7 @@ thirdPartyAudit {
      'io.netty.util.internal.shaded.org.jctools.util.UnsafeRefArrayAccess',
     )
 }
+
+allprojects {
+    version = opensearch_version + '.0'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "3.2.0-SNAPSHOT")
+        version_qualifier = System.getProperty("build.version_qualifier", "")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         version_tokens = opensearch_version.tokenize('-')
@@ -34,6 +35,16 @@ buildscript {
     dependencies {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"
+    }
+}
+
+allprojects {
+    version = opensearch_version.tokenize('-')[0] + '.0'
+    if (version_qualifier) {
+        version += "-${version_qualifier}"
+    }
+    if (isSnapshot) {
+        version += "-SNAPSHOT"
     }
 }
 
@@ -355,8 +366,4 @@ thirdPartyAudit {
      'io.netty.util.internal.shaded.org.jctools.util.UnsafeLongArrayAccess',
      'io.netty.util.internal.shaded.org.jctools.util.UnsafeRefArrayAccess',
     )
-}
-
-allprojects {
-    version = opensearch_version + '.0'
 }


### PR DESCRIPTION
tested locally

```
george.zhai@georgezhai-opensearch86:~/src/github.com/cluster-etcd$ ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=3.2.0 -Dbuild.snapshot=false -Dbuild.version_qualifier=  
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.14/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build 
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.14
  OS Info               : Linux 6.1.123+ (amd64)
  JDK Version           : 21 (Eclipse Temurin JDK)
  JAVA_HOME             : /usr/lib/jvm/jdk-21.0.2+13.UBER1
  Random Testing Seed   : 5D2106240807DEE3
  Crypto Standard       : any-supported
=======================================

[Incubating] Problems report is available at: file:///home/user/src/github.com/cluster-etcd/build/reports/problems/problems-report.html

BUILD SUCCESSFUL in 13s
18 actionable tasks: 8 executed, 10 up-to-date
george.zhai@georgezhai-opensearch86:~/src/github.com/cluster-etcd$ ls -ltr build/distributions/cluster-etcd*
-rw-r--r-- 1 george.zhai user    43488 Aug  1 04:01 build/distributions/cluster-etcd-3.2.0.0.jar
-rw-r--r-- 1 george.zhai user 13761307 Aug  1 04:01 build/distributions/cluster-etcd-3.2.0.0.zip
-rw-r--r-- 1 george.zhai user      998 Aug  1 04:01 build/distributions/cluster-etcd-3.2.0.0.pom
-rw-r--r-- 1 george.zhai user   146729 Aug  1 04:01 build/distributions/cluster-etcd-3.2.0.0-javadoc.jar
-rw-r--r-- 1 george.zhai user    21993 Aug  1 04:01 build/distributions/cluster-etcd-3.2.0.0-sources.jar
```