### PR TITLE
Add support for search unit groups

### DIFF
--- a/src/main/java/org/opensearch/cluster/etcd/ClusterETCDPlugin.java
+++ b/src/main/java/org/opensearch/cluster/etcd/ClusterETCDPlugin.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 
 public class ClusterETCDPlugin extends Plugin implements ClusterPlugin, ActionPlugin {
+
     private ClusterService clusterService;
     private ETCDWatcher etcdWatcher;
     private ETCDHeartbeat etcdHeartbeat;
@@ -76,7 +77,7 @@ public class ClusterETCDPlugin extends Plugin implements ClusterPlugin, ActionPl
 
             etcdWatcher = new ETCDWatcher(
                 localNode,
-                getNodeKey(localNode, clusterName),
+                getNodeGoalStateKey(localNode, clusterName),
                 new ChangeApplierService(clusterService.getClusterApplierService()),
                 etcdClient,
                 clusterName
@@ -89,8 +90,8 @@ public class ClusterETCDPlugin extends Plugin implements ClusterPlugin, ActionPl
         }
     }
 
-    private ByteSequence getNodeKey(DiscoveryNode localNode, String clusterName) {
-        String goalStatePath = ETCDPathUtils.buildSearchUnitGoalStatePath(clusterName, localNode.getName());
+    private ByteSequence getNodeGoalStateKey(DiscoveryNode localNode, String clusterName) {
+        String goalStatePath = ETCDPathUtils.buildSearchUnitGoalStatePath(localNode, clusterName);
         return ByteSequence.from(goalStatePath, StandardCharsets.UTF_8);
     }
 

--- a/src/main/java/org/opensearch/cluster/etcd/ETCDHeartbeat.java
+++ b/src/main/java/org/opensearch/cluster/etcd/ETCDHeartbeat.java
@@ -69,7 +69,7 @@ public class ETCDHeartbeat {
         this.etcdClient = etcdClient;
         this.scheduler = createScheduler();
         String clusterName = clusterService.getClusterName().value();
-        String statePath = ETCDPathUtils.buildNodeActualStatePath(clusterName, nodeName);
+        String statePath = ETCDPathUtils.buildSearchUnitActualStatePath(localNode, clusterName);
         this.nodeStateKey = ByteSequence.from(statePath, StandardCharsets.UTF_8);
         this.nodeEnvironment = nodeEnvironment;
         this.clusterService = clusterService;

--- a/src/main/java/org/opensearch/cluster/etcd/ETCDPathUtils.java
+++ b/src/main/java/org/opensearch/cluster/etcd/ETCDPathUtils.java
@@ -4,26 +4,34 @@
  */
 package org.opensearch.cluster.etcd;
 
+import org.opensearch.cluster.node.DiscoveryNode;
+
 /**
  * Utility class for constructing ETCD paths used by the cluster-etcd plugin.
  * These paths align with the standardized control plane and data plane path structure.
  */
 public class ETCDPathUtils {
+    private static final String DEFAULT_SEARCH_UNIT_GROUP = "search-unit";
+    private static final String SEARCH_UNIT_GROUP_ATTRIBUTE = "search_unit_group";
+    private static final String SEARCH_UNIT_NAME_ATTRIBUTE = "search_unit";
 
     public static String buildSearchUnitConfigPath(String clusterName, String searchName) {
         return "/" + clusterName + "/search-unit/" + searchName + "/conf";
     }
 
-    public static String buildSearchUnitGoalStatePath(String clusterName, String searchName) {
-        return "/" + clusterName + "/search-unit/" + searchName + "/goal-state";
+    public static String buildSearchUnitGoalStatePath(DiscoveryNode discoveryNode, String clusterName) {
+        String searchUnitGroup = discoveryNode.getAttributes().getOrDefault(SEARCH_UNIT_GROUP_ATTRIBUTE, DEFAULT_SEARCH_UNIT_GROUP);
+        String searchUnit = discoveryNode.getAttributes().getOrDefault(SEARCH_UNIT_NAME_ATTRIBUTE, discoveryNode.getName());
+        return String.join("/", "", clusterName, searchUnitGroup, searchUnit, "goal-state");
     }
 
-    public static String buildSearchUnitActualStatePath(String clusterName, String searchName) {
-        return "/" + clusterName + "/search-unit/" + searchName + "/actual-state";
+    public static String buildSearchUnitActualStatePath(DiscoveryNode discoveryNode, String clusterName) {
+        String searchUnitGroup = discoveryNode.getAttributes().getOrDefault(SEARCH_UNIT_GROUP_ATTRIBUTE, DEFAULT_SEARCH_UNIT_GROUP);
+        return String.join("/", "", clusterName, searchUnitGroup, discoveryNode.getName(), "actual-state");
     }
 
-    public static String buildNodeActualStatePath(String clusterName, String nodeName) {
-        return buildSearchUnitActualStatePath(clusterName, nodeName);
+    public static String buildSearchUnitActualStatePath(String clusterName, String nodeName) {
+        return String.join("/", "", clusterName, DEFAULT_SEARCH_UNIT_GROUP, nodeName, "actual-state");
     }
 
     /**

--- a/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
+++ b/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
@@ -356,7 +356,7 @@ public final class ETCDStateDeserializer {
             List<String> nodeNames = new ArrayList<>();
 
             for (String nodeName : nodeHealthMap.keySet()) {
-                String healthKey = ETCDPathUtils.buildNodeActualStatePath(clusterName, nodeName);
+                String healthKey = ETCDPathUtils.buildSearchUnitActualStatePath(clusterName, nodeName);
                 futures.add(kvClient.get(ByteSequence.from(healthKey, StandardCharsets.UTF_8)));
                 nodeNames.add(nodeName);
             }

--- a/src/main/java/org/opensearch/cluster/etcd/ETCDWatcher.java
+++ b/src/main/java/org/opensearch/cluster/etcd/ETCDWatcher.java
@@ -41,7 +41,7 @@ public class ETCDWatcher implements Closeable {
 
     public ETCDWatcher(
         DiscoveryNode localNode,
-        ByteSequence nodeKey,
+        ByteSequence nodeGoalStateKey,
         NodeStateApplier nodeStateApplier,
         Client etcdClient,
         String clusterName
@@ -50,8 +50,9 @@ public class ETCDWatcher implements Closeable {
         this.etcdClient = etcdClient;
         this.nodeStateApplier = nodeStateApplier;
         this.clusterName = clusterName;
-        loadInitialState(nodeKey);
-        nodeWatcher = etcdClient.getWatchClient().watch(nodeKey, WatchOption.builder().withRevision(0).build(), new NodeListener());
+        loadInitialState(nodeGoalStateKey);
+        nodeWatcher = etcdClient.getWatchClient()
+            .watch(nodeGoalStateKey, WatchOption.builder().withRevision(0).build(), new NodeListener());
     }
 
     @Override

--- a/src/test/java/org/opensearch/cluster/etcd/ETCDHeartbeatTests.java
+++ b/src/test/java/org/opensearch/cluster/etcd/ETCDHeartbeatTests.java
@@ -296,7 +296,7 @@ public class ETCDHeartbeatTests extends OpenSearchTestCase {
                 heartbeat.start();
 
                 // Wait for heartbeat to be published
-                String expectedPath = ETCDPathUtils.buildNodeActualStatePath(clusterName, nodeName);
+                String expectedPath = ETCDPathUtils.buildSearchUnitActualStatePath(localNode, clusterName);
                 await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
                     ByteSequence key = ByteSequence.from(expectedPath, StandardCharsets.UTF_8);
                     List<KeyValue> kvs = etcdClient.getKVClient().get(key).get().getKvs();
@@ -362,7 +362,7 @@ public class ETCDHeartbeatTests extends OpenSearchTestCase {
                 heartbeat.start();
 
                 // Wait for heartbeat to be published
-                String expectedPath = ETCDPathUtils.buildNodeActualStatePath(clusterName, nodeName);
+                String expectedPath = ETCDPathUtils.buildSearchUnitActualStatePath(localNode, clusterName);
                 await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
                     ByteSequence key = ByteSequence.from(expectedPath, StandardCharsets.UTF_8);
                     List<KeyValue> kvs = etcdClient.getKVClient().get(key).get().getKvs();
@@ -419,7 +419,7 @@ public class ETCDHeartbeatTests extends OpenSearchTestCase {
                 // Start heartbeat
                 heartbeat.start();
 
-                String expectedPath = ETCDPathUtils.buildNodeActualStatePath(clusterName, nodeName);
+                String expectedPath = ETCDPathUtils.buildSearchUnitActualStatePath(localNode, clusterName);
                 ByteSequence key = ByteSequence.from(expectedPath, StandardCharsets.UTF_8);
 
                 // Wait for first heartbeat
@@ -470,7 +470,7 @@ public class ETCDHeartbeatTests extends OpenSearchTestCase {
                 // Start heartbeat
                 heartbeat.start();
 
-                String expectedPath = ETCDPathUtils.buildNodeActualStatePath(clusterName, nodeName);
+                String expectedPath = ETCDPathUtils.buildSearchUnitActualStatePath(localNode, clusterName);
                 ByteSequence key = ByteSequence.from(expectedPath, StandardCharsets.UTF_8);
 
                 // Wait for heartbeat to be published
@@ -522,7 +522,7 @@ public class ETCDHeartbeatTests extends OpenSearchTestCase {
                 heartbeat.start();
 
                 // Wait for heartbeat to be published
-                String expectedPath = ETCDPathUtils.buildNodeActualStatePath(clusterName, nodeName);
+                String expectedPath = ETCDPathUtils.buildSearchUnitActualStatePath(localNode, clusterName);
                 await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
                     ByteSequence key = ByteSequence.from(expectedPath, StandardCharsets.UTF_8);
                     List<KeyValue> kvs = etcdClient.getKVClient().get(key).get().getKvs();

--- a/src/test/java/org/opensearch/cluster/etcd/ETCDWatcherTests.java
+++ b/src/test/java/org/opensearch/cluster/etcd/ETCDWatcherTests.java
@@ -148,8 +148,8 @@ public class ETCDWatcherTests extends OpenSearchTestCase {
                 // Set up health information for remote nodes
                 String remoteNodeName1 = "remote-node-1";
                 String remoteNodeName2 = "remote-node-2";
-                String healthPath1 = ETCDPathUtils.buildNodeActualStatePath(clusterName, remoteNodeName1);
-                String healthPath2 = ETCDPathUtils.buildNodeActualStatePath(clusterName, remoteNodeName2);
+                String healthPath1 = ETCDPathUtils.buildSearchUnitActualStatePath(clusterName, remoteNodeName1);
+                String healthPath2 = ETCDPathUtils.buildSearchUnitActualStatePath(clusterName, remoteNodeName2);
 
                 etcdPut(etcdClient, healthPath1, """
                     {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
For coordinator nodes in particular, we'd like to be able to support a notion of "search unit groups". That is, we can publish a goal-state to a path like:

```
/cluster-name/coordinators/default-coordinator/goal-state
```

Then all coordinators can read that same goal state, based on attributes search_unit_group=coordinators,
search_unit=default-coordinator.

Similarly, we can use the search_unit_group to publish the coordinator's heartbeats to:

```
/cluster-name/coordinators/node-name/actual-state
```

### Related Issues
N/A
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
