### PR TITLE
Try to fix permissions for add-untriaged workflow

### DIFF
--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   apply-label:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: actions/github-script@v7
         with:


### PR DESCRIPTION
### Description
I've been receiving emails regarding failures for the add-untriaged workflow.

```
Apply 'untriaged' label during issue lifecycle / apply-label
Failed in 3 seconds
```

Example workflow failure: https://github.com/msfroh/cluster-etcd/actions/runs/17137727459

That shows:
```
Unhandled error: HttpError: Resource not accessible by integration
```

Checking the Github documentation at https://docs.github.com/en/actions/tutorials/manage-your-work/add-labels-to-issues, I see that we're missing giving the GitHub action token permission to write to issues.

### Related Issues
N/A

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
